### PR TITLE
CNR-1348 MapJson now allows serialization of keys other than strings

### DIFF
--- a/RenderJsonGrailsPlugin.groovy
+++ b/RenderJsonGrailsPlugin.groovy
@@ -35,7 +35,7 @@ class RenderJsonGrailsPlugin {
     def group = "edu.berkeley.calnet.grails.plugins"
 
     // the plugin version
-    def version = "1.0.0-SNAPSHOT" // !!! Change in build.gradle too
+    def version = "1.0.1-SNAPSHOT" // !!! Change in build.gradle too
     // the version or versions of Grails the plugin is designed for
     def grailsVersion = "2.4 > *"
     // resources that are excluded from plugin packaging
@@ -66,7 +66,7 @@ Provides extensions to the standard JSON converter to add rendering features.
     def organization = [ name: "University of California, Berkeley", url: "http://www.berkeley.edu/" ]
 
     // Any additional developers beyond the author specified above.
-//    def developers = [ [ name: "Joe Bloggs", email: "joe@bloggs.net" ]]
+    def developers = [ [ name: "Søren Berg Glasius", email: "sbglasius@berkeley.edu" ]]
 
     // Location of the plugin's issue tracker.
     def issueManagement = [ system: "GitHub", url: "https://github.com/calnet-oss/grails-render-json-plugin/issues" ]
@@ -74,15 +74,9 @@ Provides extensions to the standard JSON converter to add rendering features.
     // Online location of the plugin's browseable source code.
     def scm = [ url: "https://github.com/calnet-oss/grails-render-json-plugin" ]
 
-    def doWithWebDescriptor = { xml ->
-    }
-
     // we put the doWithSpring closure in ExtendedJSON so that we can 
     // use it in unit tests as well
     def doWithSpring = ExtendedJSON.doWithSpringRegisterMarshallersClosure
-
-    def doWithDynamicMethods = { ctx ->
-    }
 
     def doWithApplicationContext = { ctx ->
         // we do this here to ensure registration happens after the Grails
@@ -91,14 +85,5 @@ Provides extensions to the standard JSON converter to add rendering features.
         ctx.getBean("jsonStringMarshaller").registerMarshaller()
         ctx.getBean("domainMarshaller").registerMarshaller()
         ctx.getBean("mapMarshaller").registerMarshaller()
-    }
-
-    def onChange = { event ->
-    }
-
-    def onConfigChange = { event ->
-    }
-
-    def onShutdown = { event ->
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ apply plugin: 'project-report'
 apply plugin: "io.spring.dependency-management"
 
 group = 'edu.berkeley.calnet.grails.plugins'
-version = '1.0.0-SNAPSHOT' // !!! Change in RenderJsonGrailsPlugin.groovy too
+version = '1.0.1-SNAPSHOT' // !!! Change in RenderJsonGrailsPlugin.groovy too
 
 sourceCompatibility = 1.7
 targetCompatibility = 1.7

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Aug 11 16:49:25 PDT 2016
+#Fri Feb 10 11:08:25 CET 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/src/groovy/edu/berkeley/render/json/marshallers/MapJsonMarshaller.groovy
+++ b/src/groovy/edu/berkeley/render/json/marshallers/MapJsonMarshaller.groovy
@@ -56,8 +56,8 @@ class MapJsonMarshaller extends MapMarshaller implements IncludesExcludesMarshal
         // remove entries with null values
         // also check includes/excludes
         def toMarshal = map.findAll {
-            log.trace("${it.key}: value=${it.value}, includeNulls=$includeNulls, shouldInclude=${shouldInclude(includeExcludeSupport, includes, excludes, map, it.key)}")
-            (includeNulls || it.value != null) && shouldInclude(includeExcludeSupport, includes, excludes, map, it.key)
+            log.trace("${it.key}: value=${it.value}, includeNulls=$includeNulls, shouldInclude=${shouldInclude(includeExcludeSupport, includes, excludes, map, it.key.toString())}")
+            (includeNulls || it.value != null) && shouldInclude(includeExcludeSupport, includes, excludes, map, it.key.toString())
         }
         log.trace("Marshalling the following: $toMarshal")
         super.marshalObject(toMarshal, converter)

--- a/test/integration/edu/berkeley/render/json/TestJSONRenderingIntegrationSpec.groovy
+++ b/test/integration/edu/berkeley/render/json/TestJSONRenderingIntegrationSpec.groovy
@@ -179,4 +179,23 @@ class TestJSONRenderingIntegrationSpec extends IntegrationSpec {
         // verify we got expected json
         writer.toString() == expected
     }
+
+    static enum EnumKeys {
+        KEY1, KEY2, KEY3
+    }
+
+
+    void "test rendering map with non-string keys"() {
+        given:
+        Map map = [(EnumKeys.KEY1): "value1", (EnumKeys.KEY2): "value2", (EnumKeys.KEY3): "value3"]
+
+        when:
+        ExtendedJSON converter = map as ExtendedJSON
+        testController.render(converter)
+
+        then:
+        String expected = '''{"KEY1":"value1","KEY2":"value2","KEY3":"value3"}'''
+        // verify we got expected json
+        writer.toString() == expected
+    }
 }

--- a/test/unit/edu/berkeley/render/json/MarshalMapSpec.groovy
+++ b/test/unit/edu/berkeley/render/json/MarshalMapSpec.groovy
@@ -59,6 +59,10 @@ class MarshalMapSpec extends Specification {
         }
     }
 
+    static enum EnumKeys {
+        KEY1, KEY2, KEY3
+    }
+
     void "test correct map marshaller registered in unit test"() {
         given:
         ExtendedJSON json = new ExtendedJSON()
@@ -86,5 +90,16 @@ class MarshalMapSpec extends Specification {
         expect:
         json.hello == "world"
         json.containsKey("nullKey") && json.nullKey == null
+    }
+
+    void "test map to json marshalling where keys are not strings"() {
+        given:
+        IncludeNullsMap map = [(EnumKeys.KEY1): "value1", (EnumKeys.KEY2): "value2", (EnumKeys.KEY3): "value3"]
+        JSONObject json = (map as ExtendedJSON).toJSONObject()
+
+        expect:
+        json.KEY1 == 'value1'
+        json.KEY2 == 'value2'
+        json.KEY3 == 'value3'
     }
 }


### PR DESCRIPTION
This was discovered when using an `Enum` as a key in Registry-Service.